### PR TITLE
fix: Reading from stdin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/jonnobrow/dev-toys-cli/internal/toys"
@@ -13,6 +14,7 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		err := toys.Run()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error running: %v", err)
 			os.Exit(1)
 		}
 	},

--- a/internal/toys/toys.go
+++ b/internal/toys/toys.go
@@ -8,10 +8,13 @@ import (
 )
 
 func Run() error {
-	program := tea.NewProgram(ui.NewModel(), tea.WithAltScreen(), tea.WithMouseCellMotion())
-	if err := program.Start(); err != nil {
-		fmt.Printf("Oops, something went wrong: %v", err)
+	program := tea.NewProgram(ui.NewModel(), tea.WithAltScreen())
+	if m, err := program.StartReturningModel(); err != nil {
 		return err
+	} else {
+		if m, ok := m.(ui.Model); ok && m.WriteToStdout {
+			fmt.Println(m.Result)
+		}
 	}
 	return nil
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -12,6 +12,7 @@ type keyMap struct {
 	Quit   key.Binding
 	Toggle key.Binding
 	Yank   key.Binding
+	Pipe   key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
@@ -21,7 +22,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right},
-		{k.Select, k.Toggle, k.Yank},
+		{k.Select, k.Toggle, k.Yank, k.Pipe},
 		{k.Help, k.Quit},
 	}
 }
@@ -54,6 +55,10 @@ var keys = keyMap{
 	Yank: key.NewBinding(
 		key.WithKeys("y", "Y"),
 		key.WithHelp("y/Y", "yank output to clipboard"),
+	),
+	Pipe: key.NewBinding(
+		key.WithKeys("|"),
+		key.WithHelp("|", "pipe output to stdout and exit"),
 	),
 	Help: key.NewBinding(
 		key.WithKeys("?"),

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -8,11 +8,11 @@ import (
 	"github.com/muesli/reflow/wrap"
 )
 
-func (m model) titleView() string {
+func (m Model) titleView() string {
 	return lipgloss.JoinHorizontal(lipgloss.Center, titleStyle.Render(m.title), subtitleStyle.Render(m.subtitle))
 }
 
-func (m model) statusView() string {
+func (m Model) statusView() string {
 
 	var statusComponents []string
 
@@ -29,7 +29,7 @@ func (m model) statusView() string {
 	return strings.Join(statusComponents, " | ")
 }
 
-func (m model) headerView() string {
+func (m Model) headerView() string {
 	availWidth := m.width
 	title := m.titleView()
 	availWidth -= lipgloss.Width(title)
@@ -48,7 +48,7 @@ func (m model) headerView() string {
 		lipgloss.PlaceHorizontal(m.width, lipgloss.Left, v))
 }
 
-func (m model) categoriesView() string {
+func (m Model) categoriesView() string {
 
 	var categories []string
 
@@ -64,7 +64,7 @@ func (m model) categoriesView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, categories...)
 }
 
-func (m model) subcommandsView() string {
+func (m Model) subcommandsView() string {
 	category := m.categories[m.cursor]
 	var subcommands []string
 
@@ -81,7 +81,7 @@ func (m model) subcommandsView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, subcommands...)
 }
 
-func (m model) inputOutputView() string {
+func (m Model) inputOutputView() string {
 	category := m.categories[m.cursor]
 	subcommand := category.Selected()
 


### PR DESCRIPTION
Previously when using stdin as the input, each key press caused the read
operation to occur, this is a problem since stdin can only be read once.

Converted stdin reading to tea.Cmd that runs on startup and stores stdin
in model.

Also added support for piping to stdout.
